### PR TITLE
Add support for joining/merging filters

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -150,6 +150,7 @@ func (s *BloomFilter) Reset() {
 	for i := uint32(0); i < s.M; i++ {
 		s.v[i] = 0
 	}
+	s.N = 0
 }
 
 // Fingerprint returns the fingerprint of a given value, as an array of index

--- a/bloom.go
+++ b/bloom.go
@@ -192,6 +192,45 @@ func (s *BloomFilter) Add(value []byte) {
 	}
 }
 
+// Join adds the items of another Bloom filter with identical dimensions to
+// the receiver. That is, all elements that are described in the
+// second filter will also described by the receiver, and the number of elements
+// of the receiver will grow by the number of elements in the added filter.
+// Note that it is implicitly assumed that both filters are disjoint! Otherwise
+// the number of elements in the joined filter must _only_ be considered an
+// upper bound and not an exact value!
+// Joining two differently dimensioned filters may yield unexpected results and
+// hence is not allowed. An error will be returned in this case, and the
+// receiver will be left unaltered.
+func (s *BloomFilter) Join(s2 *BloomFilter) error {
+	var i uint32
+	if s.n != s2.n {
+		return fmt.Errorf("filters have different dimensions (n = %d vs. %d))",
+			s.n, s2.n)
+	}
+	if s.p != s2.p {
+		return fmt.Errorf("filters have different dimensions (p = %f vs. %f))",
+			s.p, s2.p)
+	}
+	if s.k != s2.k {
+		return fmt.Errorf("filters have different dimensions (k = %d vs. %d))",
+			s.k, s2.k)
+	}
+	if s.m != s2.m {
+		return fmt.Errorf("filters have different dimensions (m = %d vs. %d))",
+			s.m, s2.m)
+	}
+	if s.M != s2.M {
+		return fmt.Errorf("filters have different dimensions (M = %d vs. %d))",
+			s.M, s2.M)
+	}
+	for i = 0; i < s.M; i++ {
+		s.v[i] |= s2.v[i]
+	}
+	s.N += s2.N
+	return nil
+}
+
 // Check returns true if the given value may be in the Bloom filter, false if it
 // is definitely not in it.
 func (s *BloomFilter) Check(value []byte) bool {

--- a/bloom.go
+++ b/bloom.go
@@ -14,10 +14,14 @@ import "io"
 
 const magicSeed = "this-is-magical"
 
+// SetError represents an error with a given message related to set operations.
 type SetError struct {
 	msg string
 }
 
+// BloomFilter represents a Bloom filter, a data structure for quickly checking
+// for set membership, with a specific desired capacity and false positive
+// probability.
 type BloomFilter struct {
 	//bit array
 	v []uint64
@@ -36,7 +40,7 @@ type BloomFilter struct {
 	M uint32
 }
 
-//Loads a filter from a reader object
+// Read loads a filter from a reader object.
 func (s *BloomFilter) Read(input io.Reader) error {
 	bs4 := make([]byte, 4)
 	bs8 := make([]byte, 8)
@@ -90,23 +94,29 @@ func (s *BloomFilter) Read(input io.Reader) error {
 
 }
 
+// NumHashFuncs returns the number of hash functions used in the Bloom filter.
 func (s *BloomFilter) NumHashFuncs() uint32 {
 	return s.k
 }
 
+// MaxNumElements returns the maximal supported number of elements in the Bloom
+// filter (capacity).
 func (s *BloomFilter) MaxNumElements() uint32 {
 	return s.n
 }
 
+// NumBits returns the number of bits used in the Bloom filter.
 func (s *BloomFilter) NumBits() uint32 {
 	return s.m
 }
 
+// FalsePositiveProb returns the chosen false positive probability for the
+// Bloom filter.
 func (s *BloomFilter) FalsePositiveProb() float64 {
 	return s.p
 }
 
-//Writes a filter to a writer object
+// Write writes the binary representation of a Bloom filter to an io.Writer.
 func (s *BloomFilter) Write(output io.Writer) error {
 	bs4 := make([]byte, 4)
 	bs8 := make([]byte, 8)
@@ -135,13 +145,15 @@ func (s *BloomFilter) Write(output io.Writer) error {
 	return nil
 }
 
+// Reset clears the Bloom filter of all elements.
 func (s *BloomFilter) Reset() {
 	for i := uint32(0); i < s.M; i++ {
 		s.v[i] = 0
 	}
 }
 
-//Returns the fingerprint of a given value, as an array of index values
+// Fingerprint returns the fingerprint of a given value, as an array of index
+// values.
 func (s *BloomFilter) Fingerprint(value []byte, fingerprint []uint32) {
 
 	hashValue1 := fnv.New64()
@@ -159,6 +171,7 @@ func (s *BloomFilter) Fingerprint(value []byte, fingerprint []uint32) {
 	}
 }
 
+// Add adds a byte array element to the Bloom filter.
 func (s *BloomFilter) Add(value []byte) {
 	var k, l uint32
 	newValue := false
@@ -178,12 +191,16 @@ func (s *BloomFilter) Add(value []byte) {
 	}
 }
 
+// Check returns true if the given value may be in the Bloom filter, false if it
+// is definitely not in it.
 func (s *BloomFilter) Check(value []byte) bool {
 	fingerprint := make([]uint32, s.k)
 	s.Fingerprint(value, fingerprint)
 	return s.CheckFingerprint(fingerprint)
 }
 
+// CheckFingerprint returns true if the given fingerprint occurs in the Bloom
+// filter, false if it does not.
 func (s *BloomFilter) CheckFingerprint(fingerprint []uint32) bool {
 	var k, l uint32
 	for i := uint32(0); i < s.k; i++ {
@@ -196,6 +213,8 @@ func (s *BloomFilter) CheckFingerprint(fingerprint []uint32) bool {
 	return true
 }
 
+// Initialize returns a new, empty Bloom filter with the given capacity (n)
+// and FP probability (p).
 func Initialize(n uint32, p float64) BloomFilter {
 	var bf BloomFilter
 	bf.n = n

--- a/bloom.go
+++ b/bloom.go
@@ -90,6 +90,22 @@ func (s *BloomFilter) Read(input io.Reader) error {
 
 }
 
+func (s *BloomFilter) NumHashFuncs() uint32 {
+	return s.k
+}
+
+func (s *BloomFilter) MaxNumElements() uint32 {
+	return s.n
+}
+
+func (s *BloomFilter) NumBits() uint32 {
+	return s.m
+}
+
+func (s *BloomFilter) FalsePositiveProb() float64 {
+	return s.p
+}
+
 //Writes a filter to a writer object
 func (s *BloomFilter) Write(output io.Writer) error {
 	bs4 := make([]byte, 4)

--- a/bloom.go
+++ b/bloom.go
@@ -10,6 +10,7 @@ import "hash/fnv"
 import "errors"
 import "math"
 import "fmt"
+
 import "io"
 
 const magicSeed = "this-is-magical"
@@ -227,7 +228,11 @@ func (s *BloomFilter) Join(s2 *BloomFilter) error {
 	for i = 0; i < s.M; i++ {
 		s.v[i] |= s2.v[i]
 	}
-	s.N += s2.N
+	if s.N+s2.N < s.N {
+		return fmt.Errorf("addition of member counts would overflow")
+	} else {
+		s.N += s2.N
+	}
 	return nil
 }
 

--- a/bloom/manage.go
+++ b/bloom/manage.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
+// BloomParams represents the parameters of the 'bloom' command line tool.
 type BloomParams struct {
 	gzip           bool
 	interactive    bool

--- a/bloom/manage.go
+++ b/bloom/manage.go
@@ -6,12 +6,13 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/DCSO/bloom"
-	"gopkg.in/urfave/cli.v1"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/DCSO/bloom"
+	"gopkg.in/urfave/cli.v1"
 )
 
 type BloomParams struct {
@@ -149,6 +150,19 @@ func checkAgainstFilter(path string, bloomParams BloomParams) {
 			}
 		}
 	}
+}
+
+func printStats(path string, bloomParams BloomParams) {
+	filter, err := bloom.LoadFilter(path, bloomParams.gzip)
+	if err != nil {
+		exitWithError(err.Error())
+	}
+	fmt.Printf("File:\t\t\t%s\n", path)
+	fmt.Printf("Capacity:\t\t%d\n", filter.MaxNumElements())
+	fmt.Printf("Elements present:\t%d\n", filter.N)
+	fmt.Printf("FP probability:\t\t%f\n", filter.FalsePositiveProb())
+	fmt.Printf("Bits:\t\t\t%d\n", filter.NumBits())
+	fmt.Printf("Hash functions:\t\t%d\n", filter.NumHashFuncs())
 }
 
 func createFilter(path string, n uint32, p float64, bloomParams BloomParams) {
@@ -304,6 +318,25 @@ func main() {
 					return err
 				}
 				checkAgainstFilter(path, bloomParams)
+				return nil
+			},
+		},
+		{
+			Name:    "show",
+			Aliases: []string{"s"},
+			Flags:   []cli.Flag{},
+			Usage:   "Shows various details about a given Bloom filter.",
+			Action: func(c *cli.Context) error {
+				path := c.Args().First()
+				bloomParams := parseBloomParams(c)
+				if path == "" {
+					exitWithError("No filename given.")
+				}
+				path, err := filepath.Abs(path)
+				if err != nil {
+					return err
+				}
+				printStats(path, bloomParams)
 				return nil
 			},
 		},

--- a/bloom/manage.go
+++ b/bloom/manage.go
@@ -391,7 +391,7 @@ func main() {
 			},
 		},
 	}
+	app.Version = "0.1.1"
 
 	app.Run(os.Args)
-
 }

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -294,7 +294,7 @@ func TestJoiningRegularMisdimensioned(t *testing.T) {
 		t.Error("joining filters with different capacity should fail")
 	}
 	if !strings.Contains(err.Error(), "different dimensions") {
-		t.Error("wring error message returned")
+		t.Error("wrong error message returned")
 	}
 	a = Initialize(100000, 0.0001)
 	b = Initialize(100000, 0.001)
@@ -303,7 +303,7 @@ func TestJoiningRegularMisdimensioned(t *testing.T) {
 		t.Error("joining filters with different FP prob should fail")
 	}
 	if !strings.Contains(err.Error(), "different dimensions") {
-		t.Error("wring error message returned")
+		t.Error("wrong error message returned")
 	}
 	a = Initialize(100000, 0.0001)
 	b = Initialize(100000, 0.0001)
@@ -313,7 +313,7 @@ func TestJoiningRegularMisdimensioned(t *testing.T) {
 		t.Error("joining filters with different number of hash funcs should fail")
 	}
 	if !strings.Contains(err.Error(), "different dimensions") {
-		t.Error("wring error message returned")
+		t.Error("wrong error message returned")
 	}
 	a = Initialize(100000, 0.0001)
 	b = Initialize(100000, 0.0001)
@@ -323,7 +323,7 @@ func TestJoiningRegularMisdimensioned(t *testing.T) {
 		t.Error("joining filters with different number of bits should fail")
 	}
 	if !strings.Contains(err.Error(), "different dimensions") {
-		t.Error("wring error message returned")
+		t.Error("wrong error message returned")
 	}
 	a = Initialize(100000, 0.0001)
 	b = Initialize(100000, 0.0001)
@@ -333,7 +333,7 @@ func TestJoiningRegularMisdimensioned(t *testing.T) {
 		t.Error("joining filters with different int array size should fail")
 	}
 	if !strings.Contains(err.Error(), "different dimensions") {
-		t.Error("wring error message returned")
+		t.Error("wrong error message returned")
 	}
 }
 

--- a/io.go
+++ b/io.go
@@ -11,10 +11,16 @@ import (
 	"os"
 )
 
+// LoadFromBytes reads a binary Bloom filter representation from a byte array
+// and returns a BloomFilter struct pointer based on it.
+// If 'gzip' is true, then compressed input will be expected.
 func LoadFromBytes(input []byte, gzip bool) (*BloomFilter, error) {
 	return LoadFromReader(bytes.NewReader(input), gzip)
 }
 
+// LoadFilter reads a binary Bloom filter representation from a file
+// and returns a BloomFilter struct pointer based on it.
+// If 'gzip' is true, then compressed input will be expected.
 func LoadFilter(path string, gzip bool) (*BloomFilter, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -25,6 +31,9 @@ func LoadFilter(path string, gzip bool) (*BloomFilter, error) {
 	return LoadFromReader(file, gzip)
 }
 
+// LoadFromReader reads a binary Bloom filter representation from an io.Reader
+// and returns a BloomFilter struct pointer based on it.
+// If 'gzip' is true, then compressed input will be expected.
 func LoadFromReader(inReader io.Reader, gzip bool) (*BloomFilter, error) {
 	var err error
 	var reader io.Reader
@@ -51,6 +60,8 @@ func LoadFromReader(inReader io.Reader, gzip bool) (*BloomFilter, error) {
 	return &filter, nil
 }
 
+// WriteFilter writes a binary Bloom filter representation for a given struct
+// to a file. If 'gzip' is true, then a compressed file will be written.
 func WriteFilter(filter *BloomFilter, path string, gzip bool) error {
 
 	file, err := os.Create(path)

--- a/io_test.go
+++ b/io_test.go
@@ -55,11 +55,11 @@ func testFromSerialized(t *testing.T, gzip bool) {
 		t.Fatal(err)
 	}
 
-	loaded_bf, err := LoadFilter(tmpfile.Name(), gzip)
+	loadedBf, err := LoadFilter(tmpfile.Name(), gzip)
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkResults(t, loaded_bf)
+	checkResults(t, loadedBf)
 }
 
 func TestFromSerialized(t *testing.T) {


### PR DESCRIPTION
This PR adds the following functionality:
- `BloomFilter.Join()` method to add the contents of a second, identically dimensioned, filter to the receiver. It is implicitly assumed that both filters are disjoint! Otherwise the updated number of elements in the joined filter must _only_ be considered an upper bound and not an exact value! Joining two differently dimensioned filters may yield unexpected results and hence is not allowed. An error will be returned in this case, and the receiver will be left unaltered.
- `bloom show` subcommand to display various key properties of a filter file (such as FP prob, capacity, number of inserted elements/hashfuncs)
- `bloom join` subcommand to join the contents of two filter files
- full comments/documentation for exported functions
- introduction of version numbers into the command line tool's help output