### PR TITLE
Feature/data

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -5,13 +5,15 @@
 
 package bloom
 
-import "encoding/binary"
-import "hash/fnv"
-import "errors"
-import "math"
-import "fmt"
-
-import "io"
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"io/ioutil"
+	"math"
+)
 
 const magicSeed = "this-is-magical"
 
@@ -36,9 +38,10 @@ type BloomFilter struct {
 	m uint32
 	//number of elements in the filter
 	N uint32
-
 	//number of 64-bit integers (generated automatically)
 	M uint32
+	//arbitrary data that we can attach to the filter
+	Data []byte
 }
 
 // Read loads a filter from a reader object.
@@ -91,6 +94,14 @@ func (s *BloomFilter) Read(input io.Reader) error {
 		s.v[i] = binary.LittleEndian.Uint64(bs8)
 	}
 
+	b, err := ioutil.ReadAll(input)
+
+	if err != nil {
+		return err
+	}
+
+	s.Data = b
+
 	return nil
 
 }
@@ -142,6 +153,9 @@ func (s *BloomFilter) Write(output io.Writer) error {
 		if err != nil {
 			return err
 		}
+	}
+	if s.Data != nil {
+		output.Write(s.Data)
 	}
 	return nil
 }

--- a/bloom/manage.go
+++ b/bloom/manage.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"bufio"
 	"fmt"
 	"github.com/DCSO/bloom"
@@ -78,16 +79,16 @@ func readInputIntoData(filter *bloom.BloomFilter, bloomParams BloomParams) {
 		fmt.Println("Interactive mode: Enter a blank line [by pressing ENTER] to exit (values will not be stored otherwise).")
 	}
 	scanner := bufio.NewScanner(os.Stdin)
-	data := make([]byte, 0, 100)
+	dataBuffer := bytes.NewBuffer([]byte(""))
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 && bloomParams.interactive {
 			break
 		}
-		data = append(data, line[:]...)
-		data = append(data, []byte("\n")...)
+		dataBuffer.Write(line)
+		dataBuffer.Write([]byte("\n"))
 	}
-	filter.Data = data
+	filter.Data = dataBuffer.Bytes()
 }
 
 func insertIntoFilter(path string, bloomParams BloomParams) {

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -38,7 +38,8 @@ func checkFilters(a BloomFilter, b BloomFilter, t *testing.T) bool {
 		b.p != a.p ||
 		b.k != a.k ||
 		b.m != a.m ||
-		b.M != a.M {
+		b.M != a.M ||
+		bytes.Compare(b.Data, a.Data) != 0 {
 		return false
 	}
 	for i := uint32(0); i < a.M; i++ {
@@ -202,6 +203,7 @@ func GenerateTestValue(length uint32) []byte {
 
 func GenerateExampleFilter(capacity uint32, p float64, samples uint32) (BloomFilter, [][]byte) {
 	filter := Initialize(capacity, p)
+	filter.Data = []byte("foobar")
 	testValues := make([][]byte, 0, samples)
 	for i := uint32(0); i < samples; i++ {
 		testValue := GenerateTestValue(100)

--- a/io_test.go
+++ b/io_test.go
@@ -5,11 +5,8 @@ package bloom
 
 import (
 	"io/ioutil"
-	"net/http"
 	"os"
 	"testing"
-
-	httpmock "gopkg.in/jarcoal/httpmock.v1"
 )
 
 func checkResults(t *testing.T, bf *BloomFilter) {
@@ -77,27 +74,6 @@ func TestFromReaderFileZip(t *testing.T) {
 	}
 	defer f.Close()
 	bf, err := LoadFromReader(f, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	checkResults(t, bf)
-}
-
-func TestFromReaderHttp(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	testBloomFile, err := ioutil.ReadFile("testdata/test.bloom")
-	if err != nil {
-		t.Fatal(err)
-	}
-	httpmock.RegisterResponder("GET", "https://localhost:9998/test.bloom",
-		httpmock.NewBytesResponder(200, testBloomFile))
-	response, err := http.Get("https://localhost:9998/test.bloom")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer response.Body.Close()
-	bf, err := LoadFromReader(response.Body, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I implemented a way to associate arbitrary data with a filter. This is useful to store some additional meta-data with the filter without resorting to an extra file. The data gets appended to the end of the filter and can store arbitrary content (e.g. JSON).

The command line utility provides a way to store and retrieve the data from the filter, and the test suite checks that the data is correctly written and read.

The Python library (flor) also has been modified to allow the extra data.

We can make use of this capability to store the query parameters associated with a Bloom filter and additional information when we generate Bloom filter responses in the API. For example, as Sascha suggested it would be useful to define a flag which makes the filter prepend the data type of an IOC to the actual value before inserting it into the filter. Currently, when downloading the resulting filter, the user does not have a way to know if the filter contains only the value or also the data type (other than remembering the parameters or naming the file accordingly). Storing this information in the JSON data of the filter makes it easy to retrieve it and always know exactly which parameters were used for generating the filter.

I also removed a test case that checked the filter against a HTTP reader. My reasoning here is that the Bloom filter does not really care where it reads its data from as long as the reader/writer supports the correct interface. Making sure the HTTPReader correctly passes the data into the filter is therefore (IMHO) not the responsibility of the filter library. Also, adding the test forces us to include a non-standard library, which I'd like to avoid to keep things simple. Please let me know if you disagree as I might not understand the motivation behind adding this test.