### PR TITLE
Spelling and option clashes

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -197,7 +197,7 @@ func (s *BloomFilter) Add(value []byte) {
 		k = uint32(fingerprint[i] / 64)
 		l = uint32(fingerprint[i] % 64)
 		v := uint64(1 << l)
-		if (s.v[k]&v) == 0 {
+		if (s.v[k] & v) == 0 {
 			newValue = true
 		}
 		s.v[k] |= v
@@ -244,9 +244,9 @@ func (s *BloomFilter) Join(s2 *BloomFilter) error {
 	}
 	if s.N+s2.N < s.N {
 		return fmt.Errorf("addition of member counts would overflow")
-	} else {
-		s.N += s2.N
 	}
+	s.N += s2.N
+
 	return nil
 }
 

--- a/bloom/manage.go
+++ b/bloom/manage.go
@@ -297,7 +297,7 @@ func main() {
 		},
 		cli.BoolFlag{
 			Name:  "each, e",
-			Usage: "print each match of a splitted string individually",
+			Usage: "print each match of a split string individually",
 		},
 		cli.StringFlag{
 			Name:  "delimiter, d",
@@ -307,18 +307,18 @@ func main() {
 		cli.StringFlag{
 			Name:  "fields, f",
 			Value: "",
-			Usage: "fields of splitted output to use in filter (a single number or a comma-separated list of numbers, zero-indexed)",
+			Usage: "fields of split output to use in filter (a single number or a comma-separated list of numbers, zero-indexed)",
 		},
 		cli.StringFlag{
 			Name:  "print-fields, pf",
 			Value: "",
-			Usage: "fields of splitted output to print for a successful match (a single number or a comma-separated list of numbers, zero-indexed).",
+			Usage: "fields of split output to print for a successful match (a single number or a comma-separated list of numbers, zero-indexed).",
 		},
 	}
 	app.Commands = []cli.Command{
 		{
 			Name:    "create",
-			Aliases: []string{"c"},
+			Aliases: []string{"cr"},
 			Flags: []cli.Flag{
 				cli.Float64Flag{Name: "p", Value: 0.01, Usage: "The desired false positive probability."},
 				cli.IntFlag{Name: "n", Value: 10000, Usage: "The desired capacity."},

--- a/bloom/manage.go
+++ b/bloom/manage.go
@@ -4,8 +4,8 @@
 package main
 
 import (
-	"bytes"
 	"bufio"
+	"bytes"
 	"fmt"
 	"github.com/DCSO/bloom"
 	"gopkg.in/urfave/cli.v1"

--- a/bloom/manage.go
+++ b/bloom/manage.go
@@ -416,7 +416,7 @@ func main() {
 		},
 		{
 			Name:    "set-data",
-			Aliases: []string{"c"},
+			Aliases: []string{"sd"},
 			Flags:   []cli.Flag{},
 			Usage:   "Sets the data associated with the Bloom filter.",
 			Action: func(c *cli.Context) error {
@@ -435,7 +435,7 @@ func main() {
 		},
 		{
 			Name:    "get-data",
-			Aliases: []string{"c"},
+			Aliases: []string{"gd"},
 			Flags:   []cli.Flag{},
 			Usage:   "Prints the data associated with the Bloom filter.",
 			Action: func(c *cli.Context) error {

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -39,7 +39,7 @@ func checkFilters(a BloomFilter, b BloomFilter, t *testing.T) bool {
 		b.k != a.k ||
 		b.m != a.m ||
 		b.M != a.M ||
-		bytes.Compare(b.Data, a.Data) != 0 {
+		!bytes.Equal(b.Data, a.Data) {
 		return false
 	}
 	for i := uint32(0); i < a.M; i++ {


### PR DESCRIPTION
I found some minor spelling issues in the command line tool, also it looks like that the new `get-data` and  `set-data` subcommands use the same short command `c`, the same as also used for the `check` and `create` subcommands. I cleaned this up a bit by keeping `c` for `check` (probably the most common) and using `cr` for `create` as well as `sd`/`gd` for `set-data` and `get-data`, respectively.
`go fmt` changes added on top.