### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: go
 sudo: false
+arch:
+  - AMD64
+  - ppc64le
 before_script:
-- go get -t ./...
-- go vet ./...
+  - go get -t ./...
+  - go vet ./...
 script: make release test
 deploy:
   provider: releases


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.