### PR TITLE
Update code to be more compliant with modern Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,17 @@ columns against the filter without having to use external tools to split and rea
 
 ## Installation on Debian-based systems
 
-Debian [command line tool](https://tracker.debian.org/pkg/golang-github-dcso-bloom) (only available in stretch-backports, buster and sid):
+Debian [command line tool](https://tracker.debian.org/pkg/golang-github-dcso-bloom):
 
     sudo apt install golang-github-dcso-bloom-cli
 
+## Installation via `go get`:
+
+    go get github.com/DCSO/bloom/...
+
 ## Installation from source
 
-These need to be run from within the GOPATH source directory for this project. To install the command line tool:
+These need to be run from within the GOPATH source directory for this project (e.g. `$GOPATH/src/github.com/DCSO/bloom`). To install the command line tool:
 
     make install
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Debian [command line tool](https://tracker.debian.org/pkg/golang-github-dcso-blo
 
 ## Installation from source
 
-These need to be run from within the GOPATH source directory for this project (e.g. `$GOPATH/src/github.com/DCSO/bloom`). To install the command line tool:
+These need to be run from within the `GOPATH` source directory for this project (e.g. `$GOPATH/src/github.com/DCSO/bloom`). To install the command line tool:
 
     make install
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/DCSO/bloom
+
+go 1.15
+
+require gopkg.in/urfave/cli.v1 v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
+gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=


### PR DESCRIPTION
This PR adds:

- Module support
- Better documentation about how to install while also building the command line tool, also where the expected location in the `GOPATH` is.