### PR TITLE
chg: [join] fix overflowing filters on join operation

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -262,14 +262,13 @@ func (s *BloomFilter) Join(s2 *BloomFilter) error {
 		return fmt.Errorf("filters have different dimensions (M = %d vs. %d))",
 			s.M, s2.M)
 	}
+	if (s.N + s2.N) > s.n {
+		return fmt.Errorf("addition of member counts would overflow")
+	}
 	for i = 0; i < s.M; i++ {
 		s.v[i] |= s2.v[i]
 	}
-	if s.N+s2.N < s.N {
-		return fmt.Errorf("addition of member counts would overflow")
-	}
 	s.N += s2.N
-
 	return nil
 }
 

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -240,7 +240,7 @@ func GenerateDisjointExampleFilter(capacity uint64, p float64, samples uint64, o
 	return filter, testValues
 }
 
-//This tests the checking of values against a given filter
+// This tests the checking of values against a given filter
 func TestChecking(t *testing.T) {
 	capacity := uint64(100000)
 	p := float64(0.001)
@@ -255,7 +255,7 @@ func TestChecking(t *testing.T) {
 	}
 }
 
-//This tests the checking of values against a given filter after resetting it
+// This tests the checking of values against a given filter after resetting it
 func TestReset(t *testing.T) {
 	capacity := uint64(100000)
 	p := float64(0.001)
@@ -271,8 +271,8 @@ func TestReset(t *testing.T) {
 	}
 }
 
-//This tests the checking of values against a given filter
-//see https://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives
+// This tests the checking of values against a given filter
+// see https://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives
 func TestFalsePositives(t *testing.T) {
 	capacity := uint64(10000)
 	p := float64(0.001)
@@ -371,6 +371,7 @@ func TestAccessors(t *testing.T) {
 func TestJoiningRegular(t *testing.T) {
 	a, aval := GenerateExampleFilter(100000, 0.0001, 10000)
 	b, bval := GenerateDisjointExampleFilter(100000, 0.0001, 20000, a)
+	c, _ := GenerateDisjointExampleFilter(100000, 0.0001, 85000, b)
 	for _, v := range bval {
 		if a.Check(v) {
 			t.Errorf("value not missing in joined filter: %s", string(v))
@@ -399,9 +400,18 @@ func TestJoiningRegular(t *testing.T) {
 			t.Errorf("value not found in joined filter: %s", string(v))
 		}
 	}
+	expected := "addition of member counts would overflow"
+	actual := b.Join(&c)
+	if actual == nil {
+		t.Errorf("Expected error %v not triggered", expected)
+	} else {
+		if actual.Error() != expected {
+			t.Errorf("Error actual = %v, and Expected = %v.", actual, expected)
+		}
+	}
 }
 
-//This benchmarks the checking of values against a given filter
+// This benchmarks the checking of values against a given filter
 func BenchmarkChecking(b *testing.B) {
 	capacity := uint64(1e9)
 	p := float64(0.001)
@@ -418,7 +428,7 @@ func BenchmarkChecking(b *testing.B) {
 	}
 }
 
-//This benchmarks the checking without using a fixed fingerprint variable (instead a temporary variable is created each time)
+// This benchmarks the checking without using a fixed fingerprint variable (instead a temporary variable is created each time)
 func BenchmarkSimpleChecking(b *testing.B) {
 	capacity := uint64(1e9)
 	p := float64(0.001)


### PR DESCRIPTION
`bloom` does not check correctly the receiving filter's capacity before merging another one into it. For instance:
```shell
$ bloom create -p 0.001 -n 100 test1.bloom
$ bloom create -p 0.001 -n 100 test2.bloom
$ find /usr/bin/ -type f -print0 | xargs -0 sha1sum | awk '{ print $1 }' > corpus.txt
$ head -n 60 corpus.txt | bloom insert test1.bloom
$ tail -n 60 corpus.txt | bloom insert test2.bloom
$ bloom join test1.bloom test2.bloom
$ bloom show test1.bloom
```
result:
```
File:			/home/jlouis/Play/bloom/test1.bloom
Capacity:		100
Elements present:	120
FP probability:		1.00e-03
Bits:			1437
Hash functions:		10
```

This PR aims at correcting this small quirck:
```
Error: addition of member counts would overflow
```
cheers,
jlouis